### PR TITLE
DE-6012 decrease MAX_POD_ID_LEN to 64

### DIFF
--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -43,7 +43,7 @@ from airflow.version import version as airflow_version
 
 MAX_LABEL_LEN = 63
 
-MAX_POD_ID_LEN = 63
+MAX_POD_ID_LEN = 64
 
 
 class PodDefaults(object):

--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -43,7 +43,7 @@ from airflow.version import version as airflow_version
 
 MAX_LABEL_LEN = 63
 
-MAX_POD_ID_LEN = 253
+MAX_POD_ID_LEN = 63
 
 
 class PodDefaults(object):


### PR DESCRIPTION
Decreasing MAX_POD_ID_LEN to 64 due to HOST_NAME_MAX being 64 on linux. This is causing the host names (same as pod names) longer than 64 characters to be truncated. It becomes an issue when Airflow is trying to fetch logs from the Kubernetes API for the pod, based on the host name.