### PR TITLE
DE-6012 set max pod id len to 63

### DIFF
--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -43,7 +43,7 @@ from airflow.version import version as airflow_version
 
 MAX_LABEL_LEN = 63
 
-MAX_POD_ID_LEN = 64
+MAX_POD_ID_LEN = 63
 
 
 class PodDefaults(object):

--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,4 +18,4 @@
 # under the License.
 #
 
-version = '1.10.12.4'
+version = '1.10.12.5'


### PR DESCRIPTION
When tested locally with the image we are using, the pod id generated with pod id len 64 is not truncated when it's assigned as the host name. But when deployed to production, it is. I assume it happens because of the encoding kubernetes is using when assigning the pod name as the host name.